### PR TITLE
Improve error checking for playground input and allow no parms

### DIFF
--- a/js/bulkhead-messages.js
+++ b/js/bulkhead-messages.js
@@ -11,5 +11,6 @@
 var bulkheadMessages = {
     'parmsGTZero': 'The Bulkhead policy parameter <b>{0}</b> is not valid because it must be greater than or equal to 1.',
     'parmsMaxValue': 'For simulation purposes, the maximum <b>{0}</b> we can accept is 10.',
-    'waitBestPractice': 'It is best practice to have a <b>waitingTaskQueue</b> equal to or larger than the <b>value</b>.'
+    'waitBestPractice': 'It is best practice to have a <b>waitingTaskQueue</b> equal to or larger than the <b>value</b>.',
+    'invalidParameters': 'Parameters entered are not valid'
 };


### PR DESCRIPTION
The playground did not accept no parameters as valid input for the @bulkhead annotation.

@Bulkhead

I needed to correct the regex expression to properly allow both @Bulkhead and @Bulkhead(). I tried both out with the sample application and they compile cleanly.

I also improved the syntax error processing for the @bulkhead annotation, adding an error message if the parameters were not valid.

This is the same fix as https://github.com/OpenLiberty/iguide-bulkhead/pull/155, but for the master branch instead of the multiPane branch.