### PR TITLE
Update to mpFaultTolerance-2.1 and mention new Fallback parameters

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -21,10 +21,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <app.name>${project.artifactId}</app.name>
 
-        <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
-        <version.dockerfile-maven-plugin>1.4.3</version.dockerfile-maven-plugin>
-        <version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>
-        <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
+        <version.maven-war-plugin>3.3.1</version.maven-war-plugin>
 
         <testServerHttpPort>9080</testServerHttpPort>
         <testServerHttpsPort>9443</testServerHttpsPort>
@@ -39,20 +36,20 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.1</version>
             <scope>provided</scope>
         </dependency>
         <!-- tag::dependencies_test[] -->
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>2.0</version>
+            <version>2.0.SP1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
-            <version>1.0</version>
+            <version>2.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -4,7 +4,7 @@
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
- 
+
   Contributors:
       IBM Corporation - initial API and implementation
 -->
@@ -13,9 +13,9 @@
 		<feature>mpContextPropagation-1.0</feature>
         <feature>servlet-4.0</feature>
         <feature>cdi-2.0</feature>
-        <feature>mpFaultTolerance-1.0</feature>
+        <feature>mpFaultTolerance-2.1</feature>
         <feature>jaxrs-2.1</feature>
     </featureManager>
-    
+
     <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"  host="*" />
 </server>

--- a/js/bulkhead-callback.js
+++ b/js/bulkhead-callback.js
@@ -12,8 +12,8 @@ var bulkheadCallBack = (function() {
 
     var bankServiceFileName = "BankService.java";
     var htmlRootDir = "/guides/iguide-bulkhead/html/";
-    var mapStepNameToScrollLine = { 'AsyncWithoutBulkhead': 23, 
-                                   'BulkheadAnnotation': 28, 
+    var mapStepNameToScrollLine = { 'AsyncWithoutBulkhead': 23,
+                                   'BulkheadAnnotation': 28,
                                    'AsyncBulkheadAnnotation': 34,
                                    'Fallback': 21 };
 
@@ -27,7 +27,7 @@ var bulkheadCallBack = (function() {
     };
 
     var __addMicroProfileFaultToleranceFeature = function() {
-        var FTFeature = "      <feature>mpFaultTolerance-1.0</feature>";
+        var FTFeature = "      <feature>mpFaultTolerance-2.1</feature>";
         var stepName = stepContent.getCurrentStepName();
         var serverFileName = "server.xml";
 
@@ -75,7 +75,7 @@ var bulkheadCallBack = (function() {
         try {
             var featureMatches = features.match(/<feature>[\s\S]*?<\/feature>/g);
             $(featureMatches).each(function (index, feature) {
-                if (feature.indexOf("<feature>mpFaultTolerance-1.0</feature>") !== -1) {
+                if (feature.indexOf("<feature>mpFaultTolerance-2.1</feature>") !== -1) {
                     match = true;
                     return false; // break out of each loop
                 }
@@ -103,7 +103,7 @@ var bulkheadCallBack = (function() {
         }
         return match;
 	};
-	
+
 	var __isMPFaultToleranceInFeatures = function(features) {
         var match = false;
         features = features.replace('\n', '');
@@ -111,7 +111,7 @@ var bulkheadCallBack = (function() {
         try {
             var featureMatches = features.match(/<feature>[\s\S]*?<\/feature>/g);
             $(featureMatches).each(function (index, feature) {
-                if (feature.indexOf("<feature>mpFaultTolerance-1.0</feature>") !== -1) {
+                if (feature.indexOf("<feature>mpFaultTolerance-2.1</feature>") !== -1) {
                     match = true;
                     return false; // break out of each loop
                 }
@@ -134,11 +134,11 @@ var bulkheadCallBack = (function() {
                 var features = editorContentBreakdown.features;
                 features = features.replace('\n', '');
                 features = features.replace(/\s/g, '');
-                if (features.length !== "<feature>mpFaultTolerance-1.0</feature><feature>cdi-2.0</feature><feature>mpContextPropagation-1.0</feature>".length) {
+                if (features.length !== "<feature>mpFaultTolerance-2.1</feature><feature>cdi-2.0</feature><feature>mpContextPropagation-1.0</feature>".length) {
                     isFTFeatureThere = false; // contains extra text
                 } else {
                     // Syntax is good.  Save off this version of server.xml.
-                    utils.saveFeatureInContent(editor, content, "mpFaultTolerance-1.0");
+                    utils.saveFeatureInContent(editor, content, "mpFaultTolerance-2.1");
                 }
             }
         } else {
@@ -219,27 +219,27 @@ var bulkheadCallBack = (function() {
         // get the last line marked for editing (the .to value).  Then, adjust it by adding
         // 1 since codeMirror starts line numbering at 0 rather than 1, and then add 1 more to
         // get to the line following.
-        var scrollToLine = editor.markTextWritable[editor.markTextWritable.length - 1].to + 2;      
+        var scrollToLine = editor.markTextWritable[editor.markTextWritable.length - 1].to + 2;
         utils.handleEditorSave(stepName, editor, validContent, __correctEditorError, scrollToLine, bankServiceFileName);
     };
 
     /**
      * Invokes the appropriate validator method for the specified step. Returns an
      * object, formed within the validator method, indicating if the contentIsCorrect
-     * (boolean) and regex groups which contain the editor contents, readOnly and 
+     * (boolean) and regex groups which contain the editor contents, readOnly and
      * writable code.
      * @param String stepName - name of the step
      * @param String content - content of the editor on the step
-     * 
-     * @return {*} -  object containing 
+     *
+     * @return {*} -  object containing
      *      codeMatched - boolean indicating if the content passed step validation
      *      The following only exists in contentInfo if codeMatched == true.
      *               [{*}] markTextWritable - array with 1 object indicating 'from' and
-     *                     'to' physical line numbers of the editable code segment 
+     *                     'to' physical line numbers of the editable code segment
      *                     within content.
-     *               [{*}] markText - array of 2 objects indicating 
-     *                     'from' and 'to' physical line numbers of the readonly 
-     *                     code within content, occurring before and after the 
+     *               [{*}] markText - array of 2 objects indicating
+     *                     'from' and 'to' physical line numbers of the readonly
+     *                     code within content, occurring before and after the
      *                     editable code segment.
      */
     var __checkEditorContent = function(stepName, content) {
@@ -271,7 +271,7 @@ var bulkheadCallBack = (function() {
         } else if (stepName === "Fallback") {
             __addFallbackAsyncBulkheadInEditor(stepName);
         } else if (stepName === "AddLibertyMPFaultTolerance") {
-            __addMicroProfileFaultToleranceFeature();    
+            __addMicroProfileFaultToleranceFeature();
         }
 
     };
@@ -302,7 +302,7 @@ var bulkheadCallBack = (function() {
             "    return serviceRequest;\n" +
             "  }";
         contentManager.replaceTabbedEditorContents(stepName, bankServiceFileName, 10, 13, newContent, 15);
-        // line number to scroll to = insert line + the number of lines to be insert 
+        // line number to scroll to = insert line + the number of lines to be insert
         // for this example 10 + 13 = 23
         contentManager.scrollTabbedEditorToView(stepName, bankServiceFileName, mapStepNameToScrollLine[stepName]);
     };
@@ -367,10 +367,10 @@ var bulkheadCallBack = (function() {
         var match = false;
         try {
             var pattern = ";\\s*}\\s*" +
-                "@Asynchronous\\s*@Bulkhead\\s*\\(\\s*value\\s*=\\s*50\\s*,\\s*" + 
+                "@Asynchronous\\s*@Bulkhead\\s*\\(\\s*value\\s*=\\s*50\\s*,\\s*" +
                 "waitingTaskQueue\\s*=\\s*50\\s*\\)\\s*" +
                 "public\\s+Future\\s*<\\s*Service\\s*>\\s*serviceForVFA\\s*\\(\\s*int\\s+counterForVFA\\s*\\)\\s*{\\s*" +
-                "Service\\s+chatService\\s*=\\s*new\\s+ChatSession\\s*\\(\\s*counterForVFA\\s*\\);\\s*" + 
+                "Service\\s+chatService\\s*=\\s*new\\s+ChatSession\\s*\\(\\s*counterForVFA\\s*\\);\\s*" +
                 "return\\s+executor\\s*.\\s*completedFuture\\s*\\(\\s*chatService\\s*\\);\\s*" +
                 "}\\s*}";
             var regExp = new RegExp(pattern, "g");
@@ -382,7 +382,7 @@ var bulkheadCallBack = (function() {
         return match;
     };
 
-    var __validateEditorContent_AsyncBulkheadStep = function(content) {       
+    var __validateEditorContent_AsyncBulkheadStep = function(content) {
         var contentInfo={codeMatched: false};
         try {
             var pattern = "([\\s\\S]ManagedExecutor\\s+executor\\s*=\\s*ManagedExecutor\\.builder\\(\\)\\.propagated\\(\\s*ThreadContext\\.APPLICATION\\s*\\)\\.build\\(\\);\\s*)" +      // readonly boundary
@@ -391,10 +391,10 @@ var bulkheadCallBack = (function() {
             "return\\s+bankService\\s*.\\s*serviceForVFA\\s*\\(\\s*counter\\s*\\)\\s*;\\s*" +
             "})" +
             "(\\s*)" +
-            "(@Asynchronous\\s*@Bulkhead\\s*\\(\\s*value\\s*=\\s*50\\s*,\\s*" + 
+            "(@Asynchronous\\s*@Bulkhead\\s*\\(\\s*value\\s*=\\s*50\\s*,\\s*" +
             "waitingTaskQueue\\s*=\\s*50\\s*\\)\\s*" +
             "public\\s+Future\\s*<\\s*Service\\s*>\\s*serviceForVFA\\s*\\(\\s*int\\s+counterForVFA\\s*\\)\\s*{\\s*" +
-            "Service\\s+chatService\\s*=\\s*new\\s+ChatSession\\s*\\(\\s*counterForVFA\\s*\\);\\s*" + 
+            "Service\\s+chatService\\s*=\\s*new\\s+ChatSession\\s*\\(\\s*counterForVFA\\s*\\);\\s*" +
             "return\\s+executor\\s*.\\s*completedFuture\\s*\\(\\s*chatService\\s*\\);\\s*" +
             "})" +
             "(\\s*}[\\s\\S]*)";
@@ -414,8 +414,8 @@ var bulkheadCallBack = (function() {
                 var annotationLines = utils.countLinesOfContent(annotation) +1;
                 var end = groups[5];
                 var endLines = utils.countLinesOfContent(end);
-    
-                var markText = [{from: 1, to: startLines}, 
+
+                var markText = [{from: 1, to: startLines},
                                 {from: startLines + methodLines + 1, to: startLines + methodLines + middleLines},
                                 {from: startLines + methodLines + middleLines + annotationLines + 1, to: startLines + methodLines + middleLines + annotationLines + endLines}];
                 var markTextWritable = [{from: startLines + 1, to: startLines + methodLines},
@@ -423,7 +423,7 @@ var bulkheadCallBack = (function() {
 
                 contentInfo.markText = markText;
                 contentInfo.markTextWritable = markTextWritable;
-            } 
+            }
         } catch (ex) {
 
         }
@@ -432,7 +432,7 @@ var bulkheadCallBack = (function() {
 
     var __validateEditorContent_FallbackStep = function(content) {
         var pattern = "([\\s\\S]*return bankService.serviceForVFA\\(counter\\);\\s*" +   // readonly boundary
-                      "}\\s*)" + 
+                      "}\\s*)" +
                       "(@Fallback\\s*\\(\\s*ServiceFallbackHandler\\s*\\.\\s*class\\s*\\))" +
                       "(\\s*@Asynchronous[\\s\\S]*)";   // readonly boundary
 
@@ -489,7 +489,7 @@ var bulkheadCallBack = (function() {
 
         contentManager.focusTabbedEditorByName(stepName, bankServiceFileName);
         contentManager.resetTabbedEditorContents(stepName, bankServiceFileName);
-   
+
         var params = [];
         var constructAnnotation = function(params) {
             var bulkheadAnnotation = "  @Asynchronous\n" +
@@ -513,7 +513,7 @@ var bulkheadCallBack = (function() {
 
         if (hasRequestForVFAMethod === true) {
 			__updateAsyncBulkheadMethodInEditor(stepName, false);
-        }       
+        }
     };
 
     var listenToEditorForAsyncBulkhead = function(editor) {
@@ -535,7 +535,7 @@ var bulkheadCallBack = (function() {
         contentManager.resetTabbedEditorContents(stepName, bankServiceFileName);
         var content = contentManager.getTabbedEditorContents(stepName, bankServiceFileName);
         var newContent =
-            "  @Fallback(ServiceFallbackHandler.class)"; + 
+            "  @Fallback(ServiceFallbackHandler.class)"; +
         contentManager.replaceTabbedEditorContents(stepName, bankServiceFileName, 20, 20, newContent, 1);
         contentManager.scrollTabbedEditorToView(stepName, bankServiceFileName, mapStepNameToScrollLine[stepName]);
     };
@@ -557,7 +557,7 @@ var bulkheadCallBack = (function() {
         var hasServiceForVFAMethod = __checkServiceForVFAMethod(content);
 
         var newContent = "  public Future<Service> requestForVFA() {\n" +
-                         "    int counter = ++counterForVFA;\n" + 
+                         "    int counter = ++counterForVFA;\n" +
                          "    return bankService.serviceForVFA(counter);\n" +
                          "  }\n";
 
@@ -576,8 +576,8 @@ var bulkheadCallBack = (function() {
 
     var __browserVirtualAdvisorBaseURL = "https://global-ebank.openliberty.io/virtualFinancialAdvisor/";
     var handleNewChatRequestInBrowser = function(stepName, requestNum) {
-        var browserChatHTML = htmlRootDir + "virtual-financial-advisor-chat.html";  
-        var browserContentHTML = htmlRootDir + "virtual-financial-advisor-connecting.html";  
+        var browserChatHTML = htmlRootDir + "virtual-financial-advisor-chat.html";
+        var browserContentHTML = htmlRootDir + "virtual-financial-advisor-connecting.html";
         var browserUrl = __browserVirtualAdvisorBaseURL + "Advisor" + requestNum;
         var browserErrorUrl = __browserVirtualAdvisorBaseURL + "error";
         var requestLimits = 1;
@@ -595,7 +595,7 @@ var bulkheadCallBack = (function() {
             }
         } else if (stepName === "ExampleScenario") {
             requestLimits = 2;
-            if (requestNum >= requestLimits) {        
+            if (requestNum >= requestLimits) {
                 browserContentHTML = htmlRootDir + "virtual-financial-advisor-no-available.html";
                 browserUrl = browserErrorUrl;
             }
@@ -630,7 +630,7 @@ var bulkheadCallBack = (function() {
             requestLimits = 2;
             if (requestNum === 2) {
                 browser.setBrowserContent(htmlRootDir + "virtual-financial-advisor-processing.html");
-                __incrementCounts(stepName, 2, 51, ".busyCount", __browserVirtualAdvisorBaseURL + "waitingqueue", 
+                __incrementCounts(stepName, 2, 51, ".busyCount", __browserVirtualAdvisorBaseURL + "waitingqueue",
                                  htmlRootDir + "virtual-financial-advisor-waitingqueue.html", true);
                 return;
             } else if (requestNum === 3) {
@@ -714,7 +714,7 @@ var bulkheadCallBack = (function() {
                 var matchPattern = "@Asynchronous\\s*@Bulkhead\\s*(\\(([^\\(\\)])*?\\))?\\s*public Future<Service> serviceForVFA";
                 var regexToMatch = new RegExp(matchPattern, "g");
                 var groups = regexToMatch.exec(content);
-                var annotation = groups[1];                
+                var annotation = groups[1];
                 var value;
                 var waitingTaskQueue;
                 var errorPosted = false;
@@ -723,7 +723,7 @@ var bulkheadCallBack = (function() {
                     // Parameters were specified in the annotation
                     var params = annotation.replace(/[{\s()}]/g, ''); // Remove whitespace and parenthesis
                     params = params.split(',');
-    
+
                     // Parse their annotation for values
                     params.forEach(function(param, index){
                         var validParameters = false;
@@ -739,23 +739,23 @@ var bulkheadCallBack = (function() {
                             editor.createCustomErrorMessage(bulkhead_messages.INVALID_PARMS);
                             errorPosted = true;
                         }
-                    });    
+                    });
                 }
 
                 if (!errorPosted) {
                     // Parameter value(s) syntax is good....check the values entered.
                     if (value != undefined) {
-                        if (!utils.isInteger(value) || value < 1) {                        
+                        if (!utils.isInteger(value) || value < 1) {
                             editor.createCustomErrorMessage(utils.formatString(bulkhead_messages.PARMS_GT_ZERO, ["value"]));
                             errorPosted = true;
                         } else if (value > 10) {
                             editor.createCustomErrorMessage(utils.formatString(bulkhead_messages.PARMS_MAX_VALUE,["value"]));
                             errorPosted = true;
-                        }    
+                        }
                     } else {
                         value = 10; // Set to default value
                     }
-                    
+
                     if (waitingTaskQueue != undefined) {
                         if(!utils.isInteger(waitingTaskQueue) || waitingTaskQueue < 1) {
                             editor.createCustomErrorMessage(utils.formatString(bulkhead_messages.PARMS_GT_ZERO, ["waitingTaskQueue"]));
@@ -768,7 +768,7 @@ var bulkheadCallBack = (function() {
                         waitingTaskQueue = 10;  // Set to default value
                     }
                 }
-                
+
                 if (!errorPosted) {
                     // All looks good so far...update the playground.
                     if (waitingTaskQueue < value) {
@@ -777,8 +777,8 @@ var bulkheadCallBack = (function() {
                     } else {
                         // Clear out any previous error boxes displayed.
                         editor.closeEditorErrorBox();
-                    }        
-                    editorInstance.addCodeUpdated();          
+                    }
+                    editorInstance.addCodeUpdated();
                     // Apply the annotation values to the bulkhead.
                     // If not specified, the bulkhead will use its default value.
                     bulkhead.updateParameters.apply(bulkhead, [value, waitingTaskQueue]);

--- a/json-guides/bulkhead.json
+++ b/json-guides/bulkhead.json
@@ -6,13 +6,13 @@
     "audience": "developer",
     "repo": "https://github.com/OpenLiberty/iguide-bulkhead",
     "defaultWidgets": [
-        {   
+        {
             "displayType": "webBrowser",
             "url": "https://global-ebank.openliberty.io/welcome",
             "browserContent": "/guides/iguides-common/html/interactive-guides/bankApp-welcome.html",
             "enable": false
         },
-        {   
+        {
             "displayType": "tabbedEditor",
             "enable": false,
             "editorList": [
@@ -59,19 +59,19 @@
         }
     ],
     "configWidgets": [
-        {   
+        {
             "displayType": "webBrowser",
             "height": "350px",
             "singleColumnHeight": "450px"
         },
-        {   
+        {
             "displayType": "pod",
             "height": "50px"
         },
         {
             "displayType": "tabbedEditor",
             "height": "400px"
-        }  
+        }
     ],
     "steps": [
         {
@@ -115,7 +115,7 @@
                 "Currently, the microservice allows only one active chat session. The next chat session request fails while the Customer1 chat is still active.<br>Click <action title='Customer2 requests chat' onclick=\"bulkheadCallBack.clickChat(event, 'ExampleScenario', 2)\">Customer2 requests chat</action> to see the failure."
             ],
             "content":[
-                {   
+                {
                     "displayType": "webBrowser",
                     "url": "https://global-ebank.openliberty.io/welcome",
                     "browserContent": "/guides/iguides-common/html/interactive-guides/bankApp-welcome.html",
@@ -123,7 +123,7 @@
                     "enableRefreshButton": false,
                     "active": true
                 },
-                {   
+                {
                     "displayType": "tabbedEditor",
                     "enable": false,
                     "editorList": [
@@ -185,7 +185,7 @@
                 "As more customers request chat sessions with a virtual financial advisor, more sessions become busy. Currently, the code does not implement a limit to the number of available advisor sessions. The VirtualFinancialAdvisor microservice causes the system to slowly run out of CPU or memory resources, which affects other microservices. <br>Click <action title='50 customer chat requests' onclick=\"bulkheadCallBack.clickChat(event, 'AsyncWithoutBulkhead', 3)\">50 customer chat requests</action> to see the cascading failure."
             ],
             "content":[
-                {   
+                {
                     "displayType": "webBrowser",
                     "url": "https://global-ebank.openliberty.io/welcome",
                     "browserContent": "/guides/iguides-common/html/interactive-guides/bankApp-welcome.html",
@@ -264,7 +264,7 @@
                 "Microprofile Fault Tolerance allows microservices to handle unavailable services. It uses different policies such as Bulkhead and Fallback to guide the execution and result of some logic. The MicroProfile Fault Tolerance 1.0 feature provides an environment to support resilient microservices through patterns that include bulkheads. Enable the MicroProfile Fault Tolerance 1.0 feature in the <code>server.xml</code> file of the Open Liberty server where the VirtualFinancialAdvisor microservice runs."
             ],
             "instruction": [
-              "Add the following element declaration to the <code>featureManager</code> element that is in the <code>server.xml</code> file.<br><codeblock>&lt;feature>mpFaultTolerance-1.0&lt;/feature&gt;</codeblock><br>Alternatively, click <action title='Enable MicroProfile Fault Tolerance' onclick=\"bulkheadCallBack.addMicroProfileFaultToleranceFeatureButton(event)\">Add</action>. <br>Then, click <action title='Run' onclick=\"bulkheadCallBack.saveServerXMLButton(event)\">Run</action> on the editor menu pane."
+              "Add the following element declaration to the <code>featureManager</code> element that is in the <code>server.xml</code> file.<br><codeblock>&lt;feature>mpFaultTolerance-2.1&lt;/feature&gt;</codeblock><br>Alternatively, click <action title='Enable MicroProfile Fault Tolerance' onclick=\"bulkheadCallBack.addMicroProfileFaultToleranceFeatureButton(event)\">Add</action>. <br>Then, click <action title='Run' onclick=\"bulkheadCallBack.saveServerXMLButton(event)\">Run</action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -448,7 +448,7 @@
                                 "   <featureManager>",
 								"      <feature>cdi-2.0</feature>",
 								"      <feature>mpContextPropagation-1.0</feature>",
-                                "      <feature>mpFaultTolerance-1.0</feature>",
+                                "      <feature>mpFaultTolerance-2.1</feature>",
                                 "   </featureManager>",
                                 "   <httpEndpoint host=\"*\" id=\"defaultHttpEndpoint\" httpsPort=\"${default.https.port}\" httpPort=\"${default.http.port}\"/>",
                                 "</server>"
@@ -534,7 +534,7 @@
                                 "}",
                                 ""
 							],
-							
+
                            "readonly": [
                                 {
                                     "from": "1",
@@ -566,7 +566,7 @@
                                 "   <featureManager>",
 								"      <feature>cdi-2.0</feature>",
 								"      <feature>mpContextPropagation-1.0</feature>",
-                                "      <feature>mpFaultTolerance-1.0</feature>",
+                                "      <feature>mpFaultTolerance-2.1</feature>",
                                 "   </featureManager>",
                                 "   <httpEndpoint host=\"*\" id=\"defaultHttpEndpoint\" httpsPort=\"${default.https.port}\" httpPort=\"${default.http.port}\"/>",
                                 "</server>"
@@ -582,7 +582,7 @@
             "title": "Adding the @Fallback annotation",
             "description": [
                 "The <code>@Asynchronous</code> and <code>@Bulkhead</code> annotations together place requests for a financial advisor in a waiting queue after the number of requests exceeds the specified maximum number of concurrent requests. If the waiting queue is full, a <code>BulkheadException</code> is thrown. Let's add a fallback service to handle the exception. A fallback service runs when the main service fails. It can provide graceful failure or continued or partial operation of the original service.",
-                "The <code>@Fallback</code> annotation identifies a class or a method that automatically runs when a <code>BulkheadException</code> occurs. To use the <code>@Fallback</code> annotation, modify your <code>server.xml</code> file to <a href='#enabling-microprofile-fault-tolerance-in-open-liberty'>include the Fault Tolerance feature</a>. In our scenario, add the <code>ServiceFallbackHandler.class</code>, which implements the <code>FallbackHandler.class</code>, to allow a customer to schedule an appointment. When a customer makes a request for a chat session, and the request cannot be handled because the maximum limit of concurrent requests has been reached and the wait queue is full, the <code>ServiceFallbackHandler.handle</code> method is called. The return type of both methods, <code>ServiceFallbackHandler.handle</code> and <code>BankService.serviceForVFA</code>, must be of type <code>Future&ltService&gt</code>. Otherwise, a <code>FaultToleranceDefinitionException</code> is thrown. <br><br>For more information on using the <code>@Fallback</code> annotation to identify a method, see the <a href='https://openliberty.io/guides/circuit-breaker.html#adding-the-fallback-annotation' target='_blank' rel='noopener noreferrer'>MicroProfile Circuit Breaker </a>guide."
+                "The <code>@Fallback</code> annotation identifies a class or a method that automatically runs when a <code>BulkheadException</code> occurs. To use the <code>@Fallback</code> annotation, modify your <code>server.xml</code> file to <a href='#enabling-microprofile-fault-tolerance-in-open-liberty'>include the Fault Tolerance feature</a>. In our scenario, add the <code>ServiceFallbackHandler.class</code>, which implements the <code>FallbackHandler.class</code>, to allow a customer to schedule an appointment. When a customer makes a request for a chat session, and the request cannot be handled because the maximum limit of concurrent requests has been reached and the wait queue is full, the <code>ServiceFallbackHandler.handle</code> method is called. The return type of both methods, <code>ServiceFallbackHandler.handle</code> and <code>BankService.serviceForVFA</code>, must be of type <code>Future&ltService&gt</code>. Otherwise, a <code>FaultToleranceDefinitionException</code> is thrown. <br><br>For more information on using the <code>@Fallback</code> annotation to identify the fallback as a method instead of a class or to learn about further restricting when the fallback will run by using the <code>applyOn</code> and <code>skipOn</code> parameters of the Fallback annotation, see the <a href='https://openliberty.io/guides/circuit-breaker.html#adding-the-fallback-annotation' target='_blank' rel='noopener noreferrer'>MicroProfile Circuit Breaker </a>guide."
             ],
             "instruction": [
                 "In the <code>BankService.java</code> file, add the <code>@Fallback(ServiceFallbackHandler.class)</code> annotation on line 20.<br><codeblock>@Fallback(ServiceFallbackHandler.class)</codeblock><br>Alternatively, click <action title='Async Bulkhead annotation with Fallback' onclick=\"bulkheadCallBack.addFallbackAsyncBulkheadButton(event, 'Fallback')\">Add</action>.<br>Then, click <action title='Run' onclick=\"bulkheadCallBack.saveButtonEditorButton(event, 'Fallback')\">Run</action> on the editor menu pane.",
@@ -699,7 +699,7 @@
                                 "   <featureManager>",
 								"      <feature>cdi-2.0</feature>",
 								"      <feature>mpContextPropagation-1.0</feature>",
-                                "      <feature>mpFaultTolerance-1.0</feature>",
+                                "      <feature>mpFaultTolerance-2.1</feature>",
                                 "   </featureManager>",
                                 "   <httpEndpoint host=\"*\" id=\"defaultHttpEndpoint\" httpsPort=\"${default.https.port}\" httpPort=\"${default.http.port}\"/>",
                                 "</server>"


### PR DESCRIPTION
Copied from #183.

In reference to OpenLiberty/iguide-circuit-breaker#288, the Fallback step in the Bulkhead guide should be updated to refer to the new Fallback annotation parameters, applyOn and skipOn. Since these parameters are new with the mpFaultTolerance-2.1, the Bulkhead guide and sample app should also update references to the mpFaultTolerance feature from 1.0 to 2.1.

Updates were made to the version in the sample application's pom.xml file for javax.servlet-api, cdi-api, and microprofile-fault-tolerance-api. Also updated the server.xml file to now include mpFaultTolerance-2.1.

The guide files were updated to now have the user add the mpFaultTolerance-2.1 (was 1.0) feature, to have all the server.xml files in the tabs point to now include mpFaultTolerance-2.1, and to add a line about the new Fallback annotation parameters.